### PR TITLE
#83 ブラウザ間比較ページで、Importanceの閾値を変更してFont styleが正しくフィルタされるように修正

### DIFF
--- a/pitalium-explorer/src/main/webapp/browserDiff.html
+++ b/pitalium-explorer/src/main/webapp/browserDiff.html
@@ -67,7 +67,7 @@
 						</li>
 						<li>
 							<a class="click_prevent">
-								<input type="checkbox" class="choice" id="checkbox_FONT" checked="checked" data-rec-category="TEXT">
+								<input type="checkbox" class="choice" id="checkbox_TEXT" checked="checked" data-rec-category="TEXT">
 								<span style="margin-left:10px;">Font style</span>
 							</a>
 						</li>


### PR DESCRIPTION
Font styleについてのId名をFONTからTEXTに変更したときに修正漏れがあった。